### PR TITLE
Added canceled flag

### DIFF
--- a/BlackRaccoon/BlackRaccoon/BRRequest.h
+++ b/BlackRaccoon/BlackRaccoon/BRRequest.h
@@ -137,6 +137,7 @@
 @property (readonly) long bytesSent;                                            // will have bytes from the last FTP call
 @property (readonly) long totalBytesSent;                                       // will have bytes total sent
 @property BOOL cancelDoesNotCallDelegate;                                       // cancel closes stream without calling delegate
+@property (readonly) BOOL wasCanceled;											// returns whether a request was canceled. Useful when inspecting a request in requestCompleted:
 
 - (NSURL *)fullURLWithEscape;
 

--- a/BlackRaccoon/BlackRaccoon/BRRequest.m
+++ b/BlackRaccoon/BlackRaccoon/BRRequest.m
@@ -109,7 +109,7 @@
 @synthesize delegate;
 @synthesize streamInfo;
 @synthesize didOpenStream;
-
+@synthesize wasCanceled;
 
 //-----
 //
@@ -454,6 +454,10 @@
 - (BOOL)cancelDoesNotCallDelegate
 {
     return self.streamInfo.cancelDoesNotCallDelegate;
+}
+
+- (BOOL)wasCanceled {
+	return self.streamInfo.wasCanceled;
 }
 
 

--- a/BlackRaccoon/BlackRaccoon/BRStreamInfo.h
+++ b/BlackRaccoon/BlackRaccoon/BRStreamInfo.h
@@ -104,6 +104,7 @@
 @property long timeout;
 @property BOOL cancelRequestFlag;
 @property BOOL cancelDoesNotCallDelegate;
+@property BOOL wasCanceled;
 
 - (void) openRead: (BRRequest *) request;
 - (void) openWrite: (BRRequest *) request;

--- a/BlackRaccoon/BlackRaccoon/BRStreamInfo.m
+++ b/BlackRaccoon/BlackRaccoon/BRStreamInfo.m
@@ -293,6 +293,7 @@ dispatch_queue_t dispatch_get_local_queue()
     //----- otherwise indicate that the request to cancel was completed
     else
     {
+		self.wasCanceled = YES;
         [request.delegate requestCompleted: request];
         [request.streamInfo close: request];
     }


### PR DESCRIPTION
Added a wasCanceled flag to let consumers check to see if a request was finished due to a cancel.
